### PR TITLE
更新中文 README，添加 Xcode 16.3 特殊处理说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ by searching the most recent Xcode build logs for the `swift-frontend`
 compiler invocation. Unfortunately, after this having worked for 10 
 years Xcode 16.3 no longer logs this information by default though it 
 will if you use "Editor/Add Build Setting/Add User-Defined Setting"
-to add a value for `EMIT_FRONTEND_COMMAND_LINES` to your project's
+to add a value for `EMIT_FRONTEND_COMMAND_LINES` (set to "YES") to your project's
 `Debug` build settings, then InjectionIII can continue to work as before.
 
 ### How to use it

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -8,6 +8,10 @@
 
 Injection 能够让你在 iOS 模拟器、真机、Arm 芯片 Mac 直接运行的 iOS app 上无需重新构建或者重启你的 app 就实现更新 class 的实现、方法，添加 struct 或者 enum。节省开发者大量调试代码和设计迭代的时间。它把 Xcode 的职责从“源代码编辑器”变成“程序编辑器”，源码的修改不再仅仅保存在磁盘中而是会直接注入到运行时的程序中
 
+### 重要提示：Injection 与 Xcode 16.3
+
+InjectionIII 的工作原理是将编辑过的源文件重新编译成动态库，然后加载到你的应用程序中。它通过搜索最近的 Xcode 构建日志中的 `swift-frontend` 编译器调用来确定如何重新编译文件。不幸的是，在这个功能正常工作了 10 年之后，Xcode 16.3 默认不再记录这些信息。但是，如果你使用 "Editor/Add Build Setting/Add User-Defined Setting" 为项目的 `Debug` 构建设置添加 `EMIT_FRONTEND_COMMAND_LINES` 值，那么 InjectionIII 可以继续像以前一样工作。
+
 ### 如何使用
 
 你可以在 [github
@@ -183,4 +187,4 @@ SwiftTrace 使用了非常方便的 [https://github.com/facebook/fishhook](https
 这个出色的应用程序图标要感谢 Katya 提供的[pixel-mixer.com](http://pixel-mixer.com/)的
 
 
-$Date: 2024/11/22 $
+$Date: 2025/05/12 $

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -10,7 +10,7 @@ Injection 能够让你在 iOS 模拟器、真机、Arm 芯片 Mac 直接运行�
 
 ### 重要提示：Injection 与 Xcode 16.3
 
-InjectionIII 的工作原理是将编辑过的源文件重新编译成动态库，然后加载到你的应用程序中。它通过搜索最近的 Xcode 构建日志中的 `swift-frontend` 编译器调用来确定如何重新编译文件。不幸的是，在这个功能正常工作了 10 年之后，Xcode 16.3 默认不再记录这些信息。但是，如果你使用 "Editor/Add Build Setting/Add User-Defined Setting" 为项目的 `Debug` 构建设置添加 `EMIT_FRONTEND_COMMAND_LINES` 值，那么 InjectionIII 可以继续像以前一样工作。
+InjectionIII 的工作原理是将编辑过的源文件重新编译成动态库，然后加载到你的应用程序中。它通过搜索最近的 Xcode 构建日志中的 `swift-frontend` 编译器调用来确定如何重新编译文件。不幸的是，在这个功能正常工作了 10 年之后，Xcode 16.3 默认不再记录这些信息。但是，如果你使用 "Editor/Add Build Setting/Add User-Defined Setting" 为项目的 `Debug` 构建设置添加 `EMIT_FRONTEND_COMMAND_LINES` 值（设置为 "YES"），那么 InjectionIII 可以继续像以前一样工作。
 
 ### 如何使用
 


### PR DESCRIPTION
根据英文 README 补充了中文版本中缺失的 Xcode 16.3 特殊处理说明，确保中文文档的完整性和一致性。